### PR TITLE
PT LM Fixes

### DIFF
--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -114,6 +114,10 @@ func (c *ApiController) UpdateSubscription() {
 		c.ResponseError(err.Error())
 		return
 	}
+	if old == nil {
+		c.ResponseError("Could not find subscription to update")
+		return
+	}
 
 	stateChanged := old.State != subscription.State
 	if stateChanged {

--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -179,7 +179,7 @@ func (c *ApiController) UpdateSubscription() {
 				}
 
 				if currentState != object.SubscriptionAuthorized {
-					c.ResponseError("Restricted to Authorized subscription state only")
+					c.ResponseError("StartDate change restricted to Authorized subscription state only")
 					return
 				}
 			}
@@ -193,7 +193,7 @@ func (c *ApiController) UpdateSubscription() {
 				}
 
 				if currentState != object.SubscriptionPreFinished {
-					c.ResponseError("Restricted to PreFinished subscription state only")
+					c.ResponseError("EndDate change restricted to PreFinished subscription state only")
 					return
 				}
 			}

--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -109,7 +109,12 @@ func (c *ApiController) UpdateSubscription() {
 	isOrgAdmin := currentUser.IsAdmin
 
 	// check subscription status
-	old, _ := object.GetSubscription(subscription.Owner + "/" + subscription.Name)
+	old, err := object.GetSubscription(id)
+	if err != nil {
+		c.ResponseError(err.Error())
+		return
+	}
+
 	stateChanged := old.State != subscription.State
 	if stateChanged {
 		valid, statuses := object.SubscriptionStateCanBeChanged(old.State, subscription.State)

--- a/web/src/SubscriptionListPage.js
+++ b/web/src/SubscriptionListPage.js
@@ -177,10 +177,24 @@ class SubscriptionListPage extends BaseListPage {
         ...this.getColumnSearchProps("state"),
         render: (text, record, index) => {
           switch (text) {
-          case "Approved":
-            return Setting.getTag("success", i18next.t("permission:Approved"));
+          case "New":
+            return Setting.getTag("success", i18next.t("permission:New"));
           case "Pending":
-            return Setting.getTag("error", i18next.t("permission:Pending"));
+            return Setting.getTag("warning", i18next.t("permission:Pending"));
+          case "PreAuthorized":
+            return Setting.getTag("success", i18next.t("permission:Pre-Authorized"));
+          case "Unauthorized":
+            return Setting.getTag("error", i18next.t("permission:Unauthorized"));
+          case "Authorized":
+            return Setting.getTag("success", i18next.t("permission:Authorized"));
+          case "Started":
+            return Setting.getTag("success", i18next.t("permission:Started"));
+          case "PreFinished":
+            return Setting.getTag("warning", i18next.t("permission:PreFinished"));
+          case "Finished":
+            return Setting.getTag("success", i18next.t("permission:Finished"));
+          case "Cancelled":
+            return Setting.getTag("error", i18next.t("permission:Cancelled"));
           default:
             return null;
           }

--- a/web/src/SubscriptionListPage.js
+++ b/web/src/SubscriptionListPage.js
@@ -43,7 +43,7 @@ class SubscriptionListPage extends BaseListPage {
       submitter: this.props.account.name,
       approver: this.props.account.name,
       approveTime: moment().format(),
-      state: "Approved",
+      state: "New",
     };
   }
 


### PR DESCRIPTION
AS-6
- update subscription list web state display
- enhance error texts returning on subscription update validation errors
- fixed issue when name of subscription changed and had a panic on old version comparison

test case description 1:
1) Create an example organization
2) Signup via $casdoor-host/signup/orgName
3) Add new user an organization admin role
4) Login as new organization admin
5) Go to Subscriptions
6) Add new subscription and edit all the fields
7) Click `Save` or `Save & Exit`

test case description 2:
1) Login as new organization admin
2) Create subscription and edit fields - assign user and plan
3) change start end/date
4) Click `Save`
5) Change subscription state from `New` to `Pending`
6) Click `Save` or `Save & Exit`
