### PR TITLE
small bug fixes

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/beego/beego/utils/pagination"
+	"github.com/casdoor/casdoor/i18n"
 	"github.com/casdoor/casdoor/object"
 	"github.com/casdoor/casdoor/pt_af_logic"
 	"github.com/casdoor/casdoor/util"
@@ -192,6 +193,11 @@ func (c *ApiController) GetUser() {
 		user = userFromUserId
 	default:
 		user, err = object.GetUser(id)
+	}
+
+	if user == nil {
+		c.ResponseError(fmt.Sprintf(i18n.Translate(c.GetAcceptLanguage(), "general:The user: %s doesn't exist"), id))
+		return
 	}
 
 	if err != nil {

--- a/object/check.go
+++ b/object/check.go
@@ -392,7 +392,7 @@ func CheckUsername(username string, lang string) string {
 }
 
 func CheckUpdateUser(oldUser, user *User, lang string) string {
-	if user.DisplayName == "" {
+	if user.DisplayName == "" && user.Tag != "manager" {
 		return i18n.Translate(lang, "user:Display name cannot be empty")
 	}
 

--- a/pt_af_logic/emailer.go
+++ b/pt_af_logic/emailer.go
@@ -505,16 +505,16 @@ func getSubscriptionUpdateMessage(actor *object.User, current, old *object.Subsc
 	)
 
 	if !old.StartDate.IsZero() {
-		oldSubscriptionStartDate = old.StartDate.In(mskLoc).Format("2006-01-02 15:04:05")
+		oldSubscriptionStartDate = old.StartDate.In(mskLoc).Format("2006-01-02")
 	}
 	if !old.EndDate.IsZero() {
-		oldSubscriptionEndDate = old.EndDate.In(mskLoc).Format("2006-01-02 15:04:05")
+		oldSubscriptionEndDate = old.EndDate.In(mskLoc).Format("2006-01-02")
 	}
 	if !current.StartDate.IsZero() {
-		subscriptionStartDate = current.StartDate.In(mskLoc).Format("2006-01-02 15:04:05")
+		subscriptionStartDate = current.StartDate.In(mskLoc).Format("2006-01-02")
 	}
 	if !current.EndDate.IsZero() {
-		subscriptionEndDate = current.EndDate.In(mskLoc).Format("2006-01-02 15:04:05")
+		subscriptionEndDate = current.EndDate.In(mskLoc).Format("2006-01-02")
 	}
 
 	return &SubscriptionUpdatedMessage{
@@ -526,7 +526,7 @@ func getSubscriptionUpdateMessage(actor *object.User, current, old *object.Subsc
 		PartnerURL:                 fmt.Sprintf("%s/organizations/%s", conf.GetConfigString("origin"), organization.Name),
 		SubscriptionURL:            fmt.Sprintf("%s/subscriptions/%s/%s", conf.GetConfigString("origin"), organization.Name, current.Name),
 		ClientDisplayName:          client.DisplayName,
-		ClientURL:                  fmt.Sprintf("%s/users/%s/%s", conf.GetConfigString("origin"), organization.Name, client.Name),
+		ClientURL:                  fmt.Sprintf("%s/clients/%s/%s", conf.GetConfigString("origin"), organization.Name, client.Name),
 		OldPlanDisplayName:         oldPlanDisplayName,
 		OldPlanURL:                 fmt.Sprintf("%s/plans/%s/%s", conf.GetConfigString("origin"), organization.Name, oldPlanName),
 		PlanURL:                    fmt.Sprintf("%s/plans/%s/%s", conf.GetConfigString("origin"), organization.Name, currentPlanName),

--- a/pt_af_logic/tenant.go
+++ b/pt_af_logic/tenant.go
@@ -45,7 +45,7 @@ func CreateTenant(ctx *beegocontext.Context, subscription *object.Subscription) 
 
 	af.Token = adminLoginResp.AccessToken
 
-	tenantName := fmt.Sprintf("%s-%s", customer.Owner, customer.Name)
+	tenantName := fmt.Sprintf("%s - %s", customer.Owner, customer.Name)
 
 	// if tenant already exists - no action required
 	if tenantID, found := customer.Properties[af_client.PtPropPref+"Tenant ID"]; found {
@@ -254,7 +254,7 @@ func CreateTenant(ctx *beegocontext.Context, subscription *object.Subscription) 
 		err = notifyPTAFTenantCreated(&PTAFTenantCreatedMessage{
 			ClientName:          customer.Name,
 			ClientDisplayName:   customer.DisplayName,
-			ClientURL:           fmt.Sprintf("%s/users/%s/%s", conf.GetConfigString("origin"), customer.Owner, customer.Name),
+			ClientURL:           fmt.Sprintf("%s/clients/%s/%s", conf.GetConfigString("origin"), customer.Owner, customer.Name),
 			ServiceUserName:     serviceUserName,
 			ServiceUserPwd:      serviceUserPwd,
 			UserROName:          userROName,

--- a/pt_af_logic/types/subscription.go
+++ b/pt_af_logic/types/subscription.go
@@ -117,7 +117,6 @@ var SubscriptionStateMap = map[SubscriptionStateName]SubscriptionState{
 				SubscriptionFieldNameSubPlan,
 				SubscriptionFieldNameDiscount,
 				SubscriptionFieldNameDescription,
-				SubscriptionFieldNameComment,
 			},
 		},
 		Transitions: nil,

--- a/routers/user_role_filter.go
+++ b/routers/user_role_filter.go
@@ -31,8 +31,7 @@ var distributorAllowedUrls = map[string]bool{
 	"/api/get-plans":                     true,
 	"/api/get-users":                     true,
 	"/api/update-subscription":           true,
-	"/api/get-user":                      true,
-	"/api/get-user-application":          true,	
+	"/api/get-user-application":          true,
 }
 
 func UserRoleFilter(ctx *context.Context) {

--- a/web/src/locales/lm/data.json
+++ b/web/src/locales/lm/data.json
@@ -821,7 +821,6 @@
       "New": "Новая",
       "New Subscription": "Новая подписка",
       "Pending": "На рассмотрении",
-      "Pre-Authorized": "Pre-Authorized",
       "PreAuthorized": "Утверждена",
       "IntoCommerce": "В коммерцию",
       "PreFinished": "Завершается",

--- a/web/src/pt_lm/ClientEditPage.js
+++ b/web/src/pt_lm/ClientEditPage.js
@@ -61,7 +61,7 @@ class UserEditPage extends React.Component {
   getUser() {
     UserBackend.getUser(this.state.organizationName, this.state.userName)
       .then((data) => {
-        if (data.status === null || data.status !== "error") {
+        if ((data.status === null || data.status !== "error") && data.tag === "client") {
           this.setState({
             user: data,
           });

--- a/web/src/pt_lm/ClientListPage.js
+++ b/web/src/pt_lm/ClientListPage.js
@@ -37,6 +37,11 @@ class UserListPage extends BaseListPage {
   UNSAFE_componentWillMount() {
     super.UNSAFE_componentWillMount();
     this.getOrganization(this.state.organizationName);
+    if (Setting.isDistributor(this.props.account)) {
+      this.setState({
+        isAuthorized: false,
+      });
+    }
   }
 
   newUser() {
@@ -173,7 +178,7 @@ class UserListPage extends BaseListPage {
         ...this.getColumnSearchProps("name", true),
         render: (text, record, index) => {
           return (
-            <Link to={`/users/${record.owner}/${text}`}>
+            <Link to={`/clients/${record.owner}/${text}`}>
               {text}
             </Link>
           );

--- a/web/src/pt_lm/SubscriptionListPage.js
+++ b/web/src/pt_lm/SubscriptionListPage.js
@@ -152,7 +152,7 @@ class SubscriptionListPage extends BaseListPage {
         width: "160px",
         sorter: true,
         render: (text, record, index) => {
-          return text === "0001-01-01T00:00:00Z" ? "" : Setting.getFormattedDate(text);
+          return text === "0001-01-01T00:00:00Z" ? "" : Setting.getFormattedDateShort(Setting.getFormattedDate(text));
         },
       },
       {
@@ -162,7 +162,7 @@ class SubscriptionListPage extends BaseListPage {
         width: "160px",
         sorter: true,
         render: (text, record, index) => {
-          return text === "0001-01-01T00:00:00Z" ? "" : Setting.getFormattedDate(text);
+          return text === "0001-01-01T00:00:00Z" ? "" : Setting.getFormattedDateShort(Setting.getFormattedDate(text));
         },
       },
       {
@@ -179,7 +179,7 @@ class SubscriptionListPage extends BaseListPage {
           case "Pending":
             return Setting.getTag("warning", i18next.t("subscription:Pending"));
           case "PreAuthorized":
-            return Setting.getTag("success", i18next.t("subscription:Pre-Authorized"));
+            return Setting.getTag("success", i18next.t("subscription:PreAuthorized"));
           case "Unauthorized":
             return Setting.getTag("error", i18next.t("subscription:Unauthorized"));
           case "Authorized":

--- a/web/src/pt_lm/UserEditPage.js
+++ b/web/src/pt_lm/UserEditPage.js
@@ -61,7 +61,7 @@ class UserEditPage extends React.Component {
   getUser() {
     UserBackend.getUser(this.state.organizationName, this.state.userName)
       .then((data) => {
-        if (data.status === null || data.status !== "error") {
+        if ((data.status === null || data.status !== "error") && data.tag === "manager") {
           this.setState({
             user: data,
           });

--- a/web/src/pt_lm/UserListPage.js
+++ b/web/src/pt_lm/UserListPage.js
@@ -37,6 +37,11 @@ class UserListPage extends BaseListPage {
   UNSAFE_componentWillMount() {
     super.UNSAFE_componentWillMount();
     this.getOrganization(this.state.organizationName);
+    if (Setting.isDistributor(this.props.account)) {
+      this.setState({
+        isAuthorized: false,
+      });
+    }
   }
 
   newUser() {


### PR DESCRIPTION
AS-35 Запретить партнеру редактировать комментарий к подписке
AS-36 Исправить отображение статуса подписки "Утверждена
AS-41 Отображать даты для подписок с точностью до дня
AS-38 Ссылка на заказчика в уведомлении должна содержать clients, а не users
AS-39 Исправить формирование названий тенантов в AF
AS-40 Сделать отображаемое имя менеджера необязательным полем
AS-37 Закрыть для дистрибьютора доступ к заказчику и менеджерам по прямой ссылке